### PR TITLE
Keep stripe profile up to date with payment details

### DIFF
--- a/app/services/discourse_stripe/stripe.rb
+++ b/app/services/discourse_stripe/stripe.rb
@@ -31,6 +31,7 @@ module DiscourseStripe
 
     def customer(user, email, source)
       if user.stripe_customer_id
+        ::Stripe::Customer.update(user.stripe_customer_id, source: source)
         ::Stripe::Customer.retrieve(user.stripe_customer_id)
       else
         customer = ::Stripe::Customer.create(


### PR DESCRIPTION
This PR updates the Stripe Engine to always write back a generated token into a customer's profile.

This means that if a customer creates 2 payments with different payment methods, for the second and subsequent payments, the customer profile is updated to use the second payment method as default before the customer is charged. A side effect of this is that every time, the customers billing details are destroyed and the new details are attached (even if they are identical).

I get that this system is a bit inefficient but it stops cached payment credentials from being used.

-----
**Meta info:**
This resolves #12 