### PR TITLE
Bump stripe gem version to avoid conflict with discourse-subscriptions plugin

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,7 +4,7 @@
 # authors: Chris Beach
 # url: https://github.com/chrisbeach/discourse-paid-pinning.git
 
-gem 'stripe', '5.0.0'
+gem 'stripe', '5.29.0'
 
 load File.expand_path('../lib/discourse_paid_pinning/engine.rb', __FILE__)
 


### PR DESCRIPTION
Installing this plugin together with discourse-subscriptions caused a conflict, because both plugins try to install a different version of the stripe gem.
